### PR TITLE
feat: improve browser page pool handling and connection recovery

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-dotnettools.csdevkit",
+				"ms-dotnettools.csdevkit@prerelease",
 				"ms-azuretools.vscode-docker",
 				"GitHub.copilot-chat",
 				"GitHub.copilot-nightly",

--- a/src/BlazorReports/BlazorReports.csproj
+++ b/src/BlazorReports/BlazorReports.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\BlazorReports.Components\BlazorReports.Components.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OneOf" Version="3.0.255" />
+  </ItemGroup>
+
 </Project>

--- a/src/BlazorReports/Extensions/ReportExtensions.cs
+++ b/src/BlazorReports/Extensions/ReportExtensions.cs
@@ -79,7 +79,14 @@ public static class ReportExtensions
         {
           context.Response.ContentType = "application/pdf";
           context.Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{blazorReport.Name}.pdf\"");
-          await reportService.GenerateReport(context.Response.BodyWriter, blazorReport, token);
+          var result = await reportService.GenerateReport(context.Response.BodyWriter, blazorReport, token);
+          result.Switch(
+            success => { },
+            async serverBusyProblem =>
+            {
+              context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+              await context.Response.BodyWriter.CompleteAsync();
+            });
         })
       .Produces<FileStreamHttpResult>(200, "application/pdf");
   }
@@ -107,7 +114,14 @@ public static class ReportExtensions
         {
           context.Response.ContentType = "application/pdf";
           context.Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{blazorReport.Name}.pdf\"");
-          await reportService.GenerateReport(context.Response.BodyWriter, blazorReport, data, token);
+          var result = await reportService.GenerateReport(context.Response.BodyWriter, blazorReport, data, token);
+          result.Switch(
+            success => { },
+            async serverBusyProblem =>
+            {
+              context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+              await context.Response.BodyWriter.CompleteAsync();
+            });
         })
       .Produces<FileStreamHttpResult>(200, "application/pdf");
   }

--- a/src/BlazorReports/Models/BlazorReportsBrowserOptions.cs
+++ b/src/BlazorReports/Models/BlazorReportsBrowserOptions.cs
@@ -9,4 +9,12 @@ public class BlazorReportsBrowserOptions
   /// Configures the browser to run without a sandbox
   /// </summary>
   public bool NoSandbox { get; set; }
+  /// <summary>
+  /// Sets the maximum pool size for the browser. Default is 10
+  /// </summary>
+  public int MaxPoolSize { get; set; } = 10;
+  /// <summary>
+  /// Sets the response timeout for the browser. Default is 30 seconds
+  /// </summary>
+  public TimeSpan ResponseTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/BlazorReports/Services/Browser/BrowserPage.cs
+++ b/src/BlazorReports/Services/Browser/BrowserPage.cs
@@ -21,9 +21,20 @@ public sealed class BrowserPage : IAsyncDisposable
   /// Creates a new instance of the BrowserPage
   /// </summary>
   /// <param name="uri"> The uri of the page</param>
-  public BrowserPage(Uri uri)
+  /// <param name="browserOptions"> The browser options</param>
+  public BrowserPage(Uri uri, BlazorReportsBrowserOptions browserOptions)
   {
-    _connection = new Connection(uri);
+    _connection = new Connection(uri, browserOptions.ResponseTimeout);
+  }
+
+  /// <summary>
+  /// Initializes the connection to the browser
+  /// </summary>
+  /// <param name="stoppingToken"></param>
+  /// <returns></returns>
+  public async Task InitializeAsync(CancellationToken stoppingToken = default)
+  {
+    await _connection.InitializeAsync(stoppingToken);
   }
 
 

--- a/src/BlazorReports/Services/Browser/Problems/PoolLimitReachedProblem.cs
+++ b/src/BlazorReports/Services/Browser/Problems/PoolLimitReachedProblem.cs
@@ -1,0 +1,6 @@
+﻿namespace BlazorReports.Services.Browser.Problems;
+
+/// <summary>
+/// Represents a problem when the pool limit is reached
+/// </summary>
+public readonly record struct PoolLimitReachedProblem();

--- a/src/BlazorReports/Services/Browser/Problems/PoolLimitReachedProblem.cs
+++ b/src/BlazorReports/Services/Browser/Problems/PoolLimitReachedProblem.cs
@@ -3,4 +3,4 @@
 /// <summary>
 /// Represents a problem when the pool limit is reached
 /// </summary>
-public readonly record struct PoolLimitReachedProblem();
+internal readonly record struct PoolLimitReachedProblem();

--- a/src/BlazorReports/Services/Browser/Problems/ServerBusyProblem.cs
+++ b/src/BlazorReports/Services/Browser/Problems/ServerBusyProblem.cs
@@ -1,0 +1,6 @@
+namespace BlazorReports.Services.Browser.Problems;
+
+/// <summary>
+/// Represents a problem that occurs when the server is busy.
+/// </summary>
+public readonly record struct ServerBusyProblem();

--- a/src/BlazorReports/Services/IReportService.cs
+++ b/src/BlazorReports/Services/IReportService.cs
@@ -1,6 +1,9 @@
 using System.IO.Pipelines;
 using BlazorReports.Models;
+using BlazorReports.Services.Browser.Problems;
 using Microsoft.AspNetCore.Components;
+using OneOf;
+using OneOf.Types;
 
 namespace BlazorReports.Services;
 
@@ -18,7 +21,7 @@ public interface IReportService
   /// <typeparam name="T"> The component to use in the report </typeparam>
   /// <typeparam name="TD"> The type of data to use in the report </typeparam>
   /// <returns> The generated report </returns>
-  ValueTask GenerateReport<T, TD>(PipeWriter pipeWriter, TD data, CancellationToken cancellationToken = default)
+  ValueTask<OneOf<Success, ServerBusyProblem>> GenerateReport<T, TD>(PipeWriter pipeWriter, TD data, CancellationToken cancellationToken = default)
     where T : ComponentBase where TD : class;
 
   /// <summary>
@@ -30,7 +33,7 @@ public interface IReportService
   /// <param name="cancellationToken"> The cancellation token </param>
   /// <typeparam name="T"> The type of data to use in the report </typeparam>
   /// <returns> The generated report </returns>
-  ValueTask GenerateReport<T>(PipeWriter pipeWriter, BlazorReport blazorReport, T? data,
+  ValueTask<OneOf<Success, ServerBusyProblem>> GenerateReport<T>(PipeWriter pipeWriter, BlazorReport blazorReport, T? data,
     CancellationToken cancellationToken = default)
     where T : class;
 
@@ -41,7 +44,7 @@ public interface IReportService
   /// <param name="blazorReport"> The report to generate </param>
   /// <param name="cancellationToken"> The cancellation token </param>
   /// <returns> The generated report </returns>
-  ValueTask GenerateReport(PipeWriter pipeWriter, BlazorReport blazorReport,
+  ValueTask<OneOf<Success, ServerBusyProblem>> GenerateReport(PipeWriter pipeWriter, BlazorReport blazorReport,
     CancellationToken cancellationToken = default);
 
   /// <summary>


### PR DESCRIPTION
* Add OneOf library for clearer problem handling between methods.
* Add max pool of browser pages to prevent the service from creating pages
* Return 503 if no available browser pages to generate report after browser response timeout
* Retry websocket connection if there is any kind of error while connecting