### PR TITLE
feat: add DisableDevShmUsage browser flag to avoid crashes in contain…

### DIFF
--- a/src/BlazorReports/Models/BlazorReportsBrowserOptions.cs
+++ b/src/BlazorReports/Models/BlazorReportsBrowserOptions.cs
@@ -23,6 +23,12 @@ public class BlazorReportsBrowserOptions
   public bool NoSandbox { get; set; }
 
   /// <summary>
+  /// Configures the browser to use tmp dir instead of /dev/shm for shared memory files.
+  /// Useful for container scenarios which generally have /dev/shm size constrained.
+  /// </summary>
+  public bool DisableDevShmUsage { get; set; }
+
+  /// <summary>
   /// Sets the maximum pool size for the browser. Defaults to 4
   /// </summary>
   public int MaxBrowserPoolSize { get; set; } = 4;

--- a/src/BlazorReports/Services/BrowserServices/Browser.cs
+++ b/src/BlazorReports/Services/BrowserServices/Browser.cs
@@ -16,7 +16,7 @@ namespace BlazorReports.Services.BrowserServices;
 /// </summary>
 internal sealed class Browser(
   Process chromiumProcess,
-  DirectoryInfo devToolsActivePortDirectory,
+  DirectoryInfo dataDirectory,
   Connection connection,
   BlazorReportsBrowserOptions browserOptions,
   ILogger logger
@@ -91,9 +91,14 @@ internal sealed class Browser(
       }
       catch (Exception e)
       {
+        logger.LogError(
+          e,
+          "Failed to generate report for browser with process id {BrowserProcessId} and data directory {DevToolsActivePortDirectory}",
+          chromiumProcess.Id,
+          dataDirectory
+        );
         await DisposeBrowserPage(browserPage);
         browserPagedDisposed = true;
-        logger.LogError(e, "Failed to generate report");
         return new BrowserProblem();
       }
     }
@@ -222,7 +227,7 @@ internal sealed class Browser(
     chromiumProcess.Kill();
     chromiumProcess.Dispose();
     await connection.DisposeAsync();
-    if (devToolsActivePortDirectory.Exists)
-      Directory.Delete(devToolsActivePortDirectory.FullName, true);
+    if (dataDirectory.Exists)
+      Directory.Delete(dataDirectory.FullName, true);
   }
 }

--- a/src/BlazorReports/Services/BrowserServices/BrowserFactory.cs
+++ b/src/BlazorReports/Services/BrowserServices/BrowserFactory.cs
@@ -64,6 +64,8 @@ internal sealed class BrowserFactory(
       throw new Exception($"Could not read DevToolsActivePort file '{devToolsActivePortFile}'");
     }
 
+    browserFactoryLogger.LogDebug("Data directory used: {DataDirectory}", devToolsDirectory);
+
     var uri = new Uri($"ws://127.0.0.1:{lines[0]}{lines[1]}");
     var connection = new Connection(uri, browserOptions.ResponseTimeout);
     await connection.InitializeAsync();
@@ -114,10 +116,19 @@ internal sealed class BrowserFactory(
     if (browserOptions.NoSandbox)
       defaultChromiumArgument.Add("--no-sandbox");
 
+    if (browserOptions.DisableDevShmUsage)
+      defaultChromiumArgument.Add("--disable-dev-shm-usage");
+
+    var chromiumArguments = string.Join(" ", defaultChromiumArgument);
+    browserFactoryLogger.LogDebug(
+      "Starting Chromium process with arguments \'{ChromiumArguments}\'",
+      chromiumArguments
+    );
+
     var processStartInfo = new ProcessStartInfo
     {
       FileName = chromiumExeFileName,
-      Arguments = string.Join(" ", defaultChromiumArgument),
+      Arguments = chromiumArguments,
       CreateNoWindow = true
     };
 


### PR DESCRIPTION
Container environments generally have restricted size for /dev/shm, which causes the browser to run out of space and eventually crash.
This adds a new flag DisableDevShmUsage to the browser options that send the --disable-dev-shm-usage to the browser so that it uses /tmp instead for the shared memory files.