### PR TITLE
feat: add regex route constraint to automatically support WebApplicaton.CreateSlimBuilder

### DIFF
--- a/examples/SimpleReportServer/Program.cs
+++ b/examples/SimpleReportServer/Program.cs
@@ -1,7 +1,7 @@
 using BlazorReports.Extensions;
 using SimpleReportServer;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/examples/SimpleReportServer/SimpleReportServer.csproj
+++ b/examples/SimpleReportServer/SimpleReportServer.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorReports/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BlazorReports/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using BlazorReports.Models;
 using BlazorReports.Services;
 using BlazorReports.Services.BrowserServices;
 using BlazorReports.Services.BrowserServices.Factories;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BlazorReports.Extensions;
@@ -29,6 +31,10 @@ public static class ServiceCollectionExtensions
     services.AddSingleton<IBrowserPageFactory, BrowserPageFactory>();
     services.AddSingleton<IBrowserService, BrowserService>();
     services.AddSingleton<IReportService, ReportService>();
+
+    services.Configure<RouteOptions>(routeOptions =>
+      routeOptions.SetParameterPolicy<RegexInlineRouteConstraint>("regex")
+    );
 
     return services;
   }


### PR DESCRIPTION
Adds support for WebApplicaton.CreateSlimBuilder by configuring the regex route options on AddBlazorReports