### PR TITLE
feat: add OutputFormat option to add html output

### DIFF
--- a/examples/SimpleReportServer/Program.cs
+++ b/examples/SimpleReportServer/Program.cs
@@ -1,4 +1,5 @@
 using BlazorReports.Extensions;
+using BlazorReports.Models;
 using SimpleReportServer;
 
 var builder = WebApplication.CreateSlimBuilder(args);
@@ -16,5 +17,11 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapGroup("reports").MapBlazorReport<HelloReport, HelloReportData>();
+app.MapGroup("reports")
+  .MapBlazorReport<HelloReport, HelloReportData>(opts =>
+  {
+    opts.ReportName = "HelloReportHtml";
+    opts.OutputFormat = ReportOutputFormat.Html;
+  });
 
 app.Run();

--- a/examples/SimpleReportServer/SimpleReportServer.csproj
+++ b/examples/SimpleReportServer/SimpleReportServer.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorReports.Client/BlazorReports.Client.csproj
+++ b/src/BlazorReports.Client/BlazorReports.Client.csproj
@@ -9,6 +9,6 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
     </ItemGroup>
 </Project>

--- a/src/BlazorReports/Extensions/BlazorReportExtensions.cs
+++ b/src/BlazorReports/Extensions/BlazorReportExtensions.cs
@@ -1,0 +1,39 @@
+using BlazorReports.Models;
+
+namespace BlazorReports.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="BlazorReport" />.
+/// </summary>
+public static class BlazorReportExtensions
+{
+  /// <summary>
+  /// Gets the content type for the specified <see cref="BlazorReport" />.
+  /// </summary>
+  /// <param name="blazorReport"> The <see cref="BlazorReport" /> to get the content type for. </param>
+  /// <returns> The content type for the specified <see cref="BlazorReport" />. </returns>
+  public static string GetContentType(this BlazorReport blazorReport)
+  {
+    return blazorReport.OutputFormat switch
+    {
+      ReportOutputFormat.Pdf => "application/pdf",
+      ReportOutputFormat.Html => "text/html",
+      _ => "application/pdf"
+    };
+  }
+
+  /// <summary>
+  /// Gets the file extension for the specified <see cref="BlazorReport" />.
+  /// </summary>
+  /// <param name="blazorReport"> The <see cref="BlazorReport" /> to get the file extension for. </param>
+  /// <returns> The file extension for the specified <see cref="BlazorReport" />. </returns>
+  public static string GetFileExtension(this BlazorReport blazorReport)
+  {
+    return blazorReport.OutputFormat switch
+    {
+      ReportOutputFormat.Pdf => "pdf",
+      ReportOutputFormat.Html => "html",
+      _ => "pdf"
+    };
+  }
+}

--- a/src/BlazorReports/Extensions/ReportExtensions.cs
+++ b/src/BlazorReports/Extensions/ReportExtensions.cs
@@ -93,10 +93,12 @@ public static class ReportExtensions
           CancellationToken token
         ) =>
         {
-          context.Response.ContentType = "application/pdf";
+          var contentType = blazorReport.GetContentType();
+          var extension = blazorReport.GetFileExtension();
+          context.Response.ContentType = contentType;
           context.Response.Headers.Append(
             "Content-Disposition",
-            $"attachment; filename=\"{blazorReport.Name}.pdf\""
+            $"attachment; filename=\"{blazorReport.Name}.{extension}\""
           );
           var result = await reportService.GenerateReport(
             context.Response.BodyWriter,
@@ -118,7 +120,7 @@ public static class ReportExtensions
           }
         }
       )
-      .Produces<FileStreamHttpResult>(200, "application/pdf")
+      .Produces<FileStreamHttpResult>(200, blazorReport.GetContentType())
       .Produces(StatusCodes.Status503ServiceUnavailable);
   }
 
@@ -154,10 +156,12 @@ public static class ReportExtensions
           CancellationToken token
         ) =>
         {
-          context.Response.ContentType = "application/pdf";
+          var contentType = blazorReport.GetContentType();
+          var extension = blazorReport.GetFileExtension();
+          context.Response.ContentType = contentType;
           context.Response.Headers.Append(
             "Content-Disposition",
-            $"attachment; filename=\"{blazorReport.Name}.pdf\""
+            $"attachment; filename=\"{blazorReport.Name}.{extension}\""
           );
           var result = await reportService.GenerateReport(
             context.Response.BodyWriter,
@@ -180,7 +184,7 @@ public static class ReportExtensions
           }
         }
       )
-      .Produces<FileStreamHttpResult>(200, "application/pdf")
+      .Produces<FileStreamHttpResult>(200, blazorReport.GetContentType())
       .Produces(StatusCodes.Status503ServiceUnavailable);
   }
 

--- a/src/BlazorReports/Models/BlazorReport.cs
+++ b/src/BlazorReports/Models/BlazorReport.cs
@@ -6,6 +6,11 @@ namespace BlazorReports.Models;
 public class BlazorReport
 {
   /// <summary>
+  /// Output format for the report. Defaults to PDF.
+  /// </summary>
+  public ReportOutputFormat OutputFormat { get; set; } = ReportOutputFormat.Pdf;
+
+  /// <summary>
   /// The name of the report.
   /// </summary>
   public required string Name { get; set; }
@@ -33,7 +38,7 @@ public class BlazorReport
   /// <summary>
   /// Assets path to use for the report.
   /// </summary>
-  public Dictionary<string, string> Assets { get; set; } = new();
+  public Dictionary<string, string> Assets { get; set; } = [];
 
   /// <summary>
   /// The page settings to use for the report.

--- a/src/BlazorReports/Models/BlazorReportRegistrationOptions.cs
+++ b/src/BlazorReports/Models/BlazorReportRegistrationOptions.cs
@@ -6,6 +6,11 @@ namespace BlazorReports.Models;
 public class BlazorReportRegistrationOptions
 {
   /// <summary>
+  /// Output format for the report. Defaults to PDF.
+  /// </summary>
+  public ReportOutputFormat OutputFormat { get; set; } = ReportOutputFormat.Pdf;
+
+  /// <summary>
   /// The name of the report. This is utilized to generate the route for the report.
   /// </summary>
   public string? ReportName { get; set; }

--- a/src/BlazorReports/Models/BlazorReportRegistry.cs
+++ b/src/BlazorReports/Models/BlazorReportRegistry.cs
@@ -76,6 +76,7 @@ public class BlazorReportRegistry
       );
     var blazorReport = new BlazorReport
     {
+      OutputFormat = options?.OutputFormat ?? ReportOutputFormat.Pdf,
       Name = reportNameToUse,
       NormalizedName = normalizedReportName,
       Component = typeof(T),
@@ -124,6 +125,7 @@ public class BlazorReportRegistry
       );
     var blazorReport = new BlazorReport
     {
+      OutputFormat = options?.OutputFormat ?? ReportOutputFormat.Pdf,
       Name = reportNameToUse,
       NormalizedName = normalizedReportName,
       Component = typeof(T),

--- a/src/BlazorReports/Models/ReportOutputFormat.cs
+++ b/src/BlazorReports/Models/ReportOutputFormat.cs
@@ -1,0 +1,17 @@
+namespace BlazorReports.Models;
+
+/// <summary>
+/// Output format for the report.
+/// </summary>
+public enum ReportOutputFormat
+{
+  /// <summary>
+  /// Portable Document Format
+  /// </summary>
+  Pdf,
+
+  /// <summary>
+  /// HyperText Markup Language
+  /// </summary>
+  Html
+}


### PR DESCRIPTION
This change adds the OutputFormat option to BlazorReports to register a report to output either PDF or HTML format. This helps in debugging reports while building them.