### PR TITLE
chore: change Docker build context to current directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "Blazor Reports Development",
   "build": {
     // Sets the run context to one level up instead of the .devcontainer folder.
-    "context": "..",
+    "context": ".",
     // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
     "dockerfile": "BlazorReports.Dev.Dockerfile"
   },


### PR DESCRIPTION
Updated the Docker build context setting from parent directory to the current directory in .devcontainer/devcontainer.json to ensure the build process uses the intended files.